### PR TITLE
♻️ Refactor: 후원을 기다리는 조공 Card 컴포넌트 후원 마감 또는 목표 달성 시 버튼 비활성화

### DIFF
--- a/src/mocks/donations.js
+++ b/src/mocks/donations.js
@@ -1,7 +1,7 @@
 export const DONATIONS = [
 	{
 		status: true,
-		deadline: "2025-10-10T00:00:00.000Z",
+		deadline: "2025-04-21T00:00:00.000Z",
 		createdAt: "2025-04-15T09:53:35.947Z",
 		receivedDonations: 500000,
 		targetDonation: 1000000,
@@ -22,7 +22,7 @@ export const DONATIONS = [
 		status: true,
 		deadline: "2025-12-25T00:00:00.000Z",
 		createdAt: "2025-06-20T14:22:15.123Z",
-		receivedDonations: 750000,
+		receivedDonations: 2000000,
 		targetDonation: 2000000,
 		idolId: 1,
 		subtitle: "코엑스몰 메가박스 앞",

--- a/src/pages/List/Donation/components/Card/ProgressBar/index.jsx
+++ b/src/pages/List/Donation/components/Card/ProgressBar/index.jsx
@@ -5,15 +5,11 @@ import { progressContainer, progressContent } from "./ProgressBar.style";
 /**
  * ProgressBar 컴포넌트
  *
- * 받은 후원금(`receive`)과 목표 금액(`target`)을 기반으로
- * 진행률을 계산해 시각적으로 표시하는 프로그레스 바
+ * 달성률 전달받아 시각적으로 표시하는 프로그레스 바
  *
- * @param {number} props.receive - 현재까지 받은 후원 금액
- * @param {number} props.target - 목표 후원 금액
+ * @param {number} props.progress - 현재 달성률
  */
-function ProgressBar({ receive, target }) {
-	const progress = Math.min((receive / target) * 100, 100); // 100% 초과 방지
-
+function ProgressBar({ progress }) {
 	return (
 		<div css={progressContainer}>
 			<div css={progressContent(progress)} />

--- a/src/pages/List/Donation/components/Card/index.jsx
+++ b/src/pages/List/Donation/components/Card/index.jsx
@@ -85,10 +85,7 @@ function Card({ donation }) {
 						{/* 남은 날짜 */}
 						<span css={donationDday}>{dDay}일 남음</span>
 					</div>
-					<ProgressBar
-						receive={donation.receivedDonations}
-						target={donation.targetDonation}
-					/>
+					<ProgressBar progress={progress} />
 				</div>
 			</div>
 		</article>

--- a/src/pages/List/Donation/components/Card/index.jsx
+++ b/src/pages/List/Donation/components/Card/index.jsx
@@ -33,9 +33,17 @@ function Card({ donation }) {
 	// 남은 날짜 구하기
 	const today = new Date();
 	const deadline = new Date(donation.deadline);
-
 	const diffTime = deadline - today;
 	const dDay = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); // 일 단위로 변환
+
+	// 진행률 구하기
+	const progress = Math.min(
+		(donation.receivedDonations / donation.targetDonation) * 100,
+		100,
+	); // 100% 초과 방지
+
+	// 조건에 따라 버튼 비활성화
+	const isButtonDisabled = dDay <= 0 || progress >= 100;
 
 	return (
 		<article css={donationCardContainer}>
@@ -50,7 +58,9 @@ function Card({ donation }) {
 
 				{/* 후원하기 버튼 */}
 				<div css={donationButton}>
-					<Button size="donate-md">후원하기</Button>
+					<Button size="donate-md" disabled={isButtonDisabled}>
+						{isButtonDisabled ? "후원 마감 🎉" : "후원 하기"}
+					</Button>
 				</div>
 			</div>
 


### PR DESCRIPTION
## 📝 Summary

Card 컴포넌트 내부 버튼을 후원이 마감되거나 달성률 100%를 달성하면 비활성화 되도록 수정하였습니다.
#77 

## 🔧 Changes

- `dDay`가 0 이하이거나 `progress`가 100이면 버튼이 비활성화 되도록 하였습니다.

- 버튼 문구를 비활성화 시 `후원 마감 🎉`으로 변경하였습니다.


## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

- mock 데이터를 연결해 test 진행
   - 마감 기한을 지난 날짜로 변경
   - 받은 금액을 목표 금액과 동일하게 수정하여 달성률을 100으로 설정
 
- 마감일과 달성률 모두 disabled로 처리가 되는지 확인했습니다.

## 🖼️ Screenshots (UI 변경 시)

![스크린샷 2025-04-22 230344](https://github.com/user-attachments/assets/3e8f3d72-8c0c-4886-8326-54b4d7440eaf)

- 왼쪽은 마감일이 지난 경우
- 오른쪽은 달성률이 100%인 경우

## 📚 Additional

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->

- 아마도 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
