### PR TITLE
🎨 Feat: Donation 컴포넌트 반응형 구현

### DIFF
--- a/src/components/Button/Button.styles.js
+++ b/src/components/Button/Button.styles.js
@@ -26,7 +26,7 @@ export const getButtonStyles = (
         transform: ${disabled ? "none" : "scale(1.02)"};
     }
     // 반응형 사이즈
-    @media (max-width: 768px) {
+    @media (max-width: 426px) {
     width: ${mobileSize?.width || currentSize.width};
     height: ${mobileSize?.height || currentSize.height};
     font-size: ${mobileSize?.fontSize || currentSize.fontSize};

--- a/src/pages/List/Donation/Donation.style.js
+++ b/src/pages/List/Donation/Donation.style.js
@@ -9,7 +9,12 @@ margin-top: 50px;
 
 color: #ffffff;
 font-size: 24px;
-font-weight: 700;`;
+font-weight: 700;
+
+@media (max-width: 426px) {
+font-size: 4.27vw;
+margin-top: 10.67vw;
+}`;
 
 export const donationPageNation = css`
 position: relative;`;
@@ -36,6 +41,10 @@ export const pageNationRight = css`
   border-radius: 4px;
   }
 
+  @media (max-width: 769px) {
+  display: none;
+  }
+
 `;
 
 /**
@@ -58,5 +67,9 @@ export const pageNationLeft = css`
   &:hover {
   background-color: #1B1B1B;
   border-radius: 4px;
+  }
+
+  @media (max-width: 769px) {
+  display: none;
   }
 `;

--- a/src/pages/List/Donation/components/Card/Card.style.js
+++ b/src/pages/List/Donation/components/Card/Card.style.js
@@ -8,13 +8,18 @@ import { css } from "@emotion/react";
  * - 크기 고정
  */
 export const donationCardContainer = css`
-display: flex;
-width: 282px;
-height: 402px;
-flex-direction: column;
-justify-content: center;
-align-items: center;
-flex-shrink: 0;
+  display: flex;
+  width: 282px;
+  height: 402px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+
+  @media (max-width: 426px) {
+  width: 158px;
+  height: 303px;
+  }
 `;
 
 /**
@@ -25,6 +30,11 @@ export const donatioImgContainer = css`
   position: relative;
   width: 282px;
   height: 293px;
+
+  @media (max-width: 426px) {
+  width: 158px;
+  height: 206px;
+  }
 `;
 
 /**
@@ -32,7 +42,6 @@ export const donatioImgContainer = css`
  * - border-radius 및 overflow 처리
  */
 export const imgWrapper = css`
-  position: relative;
   width: 100%;
   height: 100%;
   border-radius: 8px;
@@ -59,7 +68,6 @@ export const overlaySvg = css`
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
   height: 100%;
   z-index: 2;
 `;
@@ -76,7 +84,13 @@ left: 22px;
 
 z-index: 3;
 
-font-size: 13px
+font-size: 13px;
+
+@media (max-width: 426px) {
+bottom: 4vw;
+left: 1.87vw;
+font-size: 2.67vw;
+}
 `;
 
 /**
@@ -99,7 +113,11 @@ display: flex;
 width: 100%;
 flex-direction: column;
 align-items: flex-start;
-gap: 8px;`;
+gap: 8px;
+
+@media (max-width: 426px) {
+gap: 1.6vw;
+}`;
 
 /**
  * 장소(서브제목) 스타일
@@ -117,6 +135,9 @@ line-height: 18px; /* 112.5% */
 letter-spacing: -0.165px;
 
 opacity: 0.4;
+
+@media (max-width: 426px) {
+font-size: 3.2vw;
 `;
 
 /**
@@ -129,6 +150,9 @@ font-size: 18px;
 font-style: normal;
 font-weight: 500;
 line-height: normal;
+
+@media (max-width: 426px) {
+font-size: 100%;
 `;
 
 /**
@@ -150,6 +174,10 @@ display: flex;
 justify-content: space-between;
 
 margin-bottom: 4px;
+
+@media (max-width: 426px) {
+margin-bottom: 0.27vw;
+};
 `;
 
 /**
@@ -176,7 +204,11 @@ font-size: 12px;
 font-style: normal;
 font-weight: 400;
 line-height: 18px; /* 150% */
-letter-spacing: -0.165px;`;
+letter-spacing: -0.165px;
+
+@media (max-width: 426px) {
+font-size: 2.67vw;
+}`;
 
 /**
  * D-Day 남은 일 수 텍스트
@@ -190,4 +222,7 @@ font-style: normal;
 font-weight: 400;
 line-height: 18px; /* 150% */
 letter-spacing: -0.165px;
-`;
+
+@media (max-width: 426px) {
+font-size: 2.67vw;
+}`;

--- a/src/pages/List/Donation/components/Card/ProgressBar/ProgressBar.style.js
+++ b/src/pages/List/Donation/components/Card/ProgressBar/ProgressBar.style.js
@@ -13,7 +13,8 @@ width: 100%;
 height: 1px;
 flex-shrink: 0;
 
-background-color: #ffffff;
+background-color: #ffffff
+;
 `;
 
 /**

--- a/src/pages/List/Donation/components/Carousel/Carousel.style.js
+++ b/src/pages/List/Donation/components/Carousel/Carousel.style.js
@@ -17,6 +17,11 @@ export const sliderTrack = (
 	transform: translateX(-${(itemWidth + gap) * startIndex}px);
 	gap: 24px;
   margin-top: 34px;
+  
+  @media (max-width: 426px) {
+  margin-top: 3.76vw;
+  gap: 1.88vw;
+  };
 `;
 
 /**


### PR DESCRIPTION
## 📝 Summary

Donation 컴포넌트 반응형 구현 했습니다.
Resolves: #78

## 🔧 Changes

- 테블릿: 768 모바일: 425로 분기점을 설정하여 반응형을 구현했습니다.

- 테블릿: 양 옆 화살표를 `display: none`으로 없앴습니다.

- 모바일: 슬라이더 내부 카드의 크기를 줄였습니다.

- 기타 `font-size`와 `gap` `margin`등을 조정하였습니다.

- 반응형 단위는 `vw`를 활용했습니다.

## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

- 개발자 도구와 테블릿, 모바일 휴대폰으로 확인하며 테스트 진행했습니다.

| 테블릿 | 모바일 |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/7142862c-9f41-42e1-b67f-95b817d8bb67) |  ![image](https://github.com/user-attachments/assets/f59555db-95c4-4fd9-857f-9620eb54ca2b) |


## 🖼️ Screenshots (UI 변경 시)

## 📚 Additional

- Card.style.js에서 `donationCardContainer`와 `donationImgContainer`는 전체 Card와 이미지 부분을 감싸는 역할을 하는데, 여기서 width와 height를 설정해놓고 나머지 요소는 100%로 주어 구현하였습니다. 그런데, 미디어 쿼리 내부 단위를 `px`에서 `vw`로 변경하면  아래와 같이 내부 요소들이 변경되는 문제점이 발생하여 우선 `px`로 단위를 고정해두었습니다.

| 오류 사진 1 | 오류 사진 2 |
|-------------|-------------|
| ![오류1](https://github.com/user-attachments/assets/a4392d60-f266-4d93-b9c4-50feac389dd7) | ![오류2](https://github.com/user-attachments/assets/21e31df0-83c5-4af5-a492-3338185d66b3) |



---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
