### PR TITLE
Feature/vote-modal-idol-select

### DIFF
--- a/src/components/CheckIdol.jsx
+++ b/src/components/CheckIdol.jsx
@@ -3,11 +3,11 @@ import { css } from "@emotion/react";
 
 // size: 아이돌 원 사이즈
 // checkSize: 체크표시 사이즈
-const CheckIdol = ({ isChecked, size, checkSize }) => {
+const CheckIdol = ({ isChecked, size, checkSize, isVote = false }) => {
 	if (!isChecked) return null;
 
 	return (
-		<div css={checkWrapper(size)}>
+		<div css={checkWrapper(size, isVote)}>
 			<div css={checkBackground(size)} />
 			<img
 				src="../public/icons/Checkmark.png"
@@ -18,10 +18,10 @@ const CheckIdol = ({ isChecked, size, checkSize }) => {
 	);
 };
 
-const checkWrapper = (size) => css`
+const checkWrapper = (size, isVote) => css`
   position: absolute;
   top: 50%;
-  left: 50%;
+  left: ${isVote ? "21%" : "50%"};
   transform: translate(-50%, -50%);
   width: ${size}px;
   height: ${size}px;
@@ -38,7 +38,7 @@ const checkBackground = (size) => css`
   transform: translate(-50%, -50%);
   width: ${size * 0.9}px;
   height: ${size * 0.9}px;
-  background: linear-gradient(271deg, #f96e68, #fe578f);
+  background: linear-gradient(271deg, #F96E68 -9.84%, #FE578F 107.18%);
   border-radius: 50%;
   opacity: 0.5;
   z-index: 0; /* 배경이 아이콘 아래에 위치하도록 */

--- a/src/pages/List/Chart/components/VoteIdolList.jsx
+++ b/src/pages/List/Chart/components/VoteIdolList.jsx
@@ -1,5 +1,6 @@
-import Circle from "../../../../components/Circle";
+import CheckIdol from "../../../../components/CheckIdol";
 /** @jsxImportSource @emotion/react */
+import Circle from "../../../../components/Circle";
 import RadioButton from "../../../../components/RadioButton";
 import {
 	IdolDetails,
@@ -36,6 +37,12 @@ export default function VoteIdolList({ idols, selectedIdolId, onSelectIdol }) {
 									alt={idol.name}
 									loading="lazy"
 									decoding="async"
+								/>
+								<CheckIdol
+									isVote={true}
+									isChecked={selectedIdolId === idol.id}
+									size={70}
+									checkSize={18}
 								/>
 								<div css={IdolInfo}>
 									<span css={Rank}>{index + 1}</span>

--- a/src/pages/List/Chart/components/VoteIdolList.styles.js
+++ b/src/pages/List/Chart/components/VoteIdolList.styles.js
@@ -39,9 +39,10 @@ export const IdolItem = css`
 `;
 
 export const RadioContent = css`
+  position: relative; /* ✅ CheckIdol 기준점 */
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 12px;
 `;
 
 export const IdolInfo = css`


### PR DESCRIPTION
투표 모달에서 사용할 수 있도록 isVote prop 추가
isVote가 true일 경우 체크 아이콘 위치를 left: 21%로 조정
투표할 아이돌 선택 시 해당 이미지 위에 체크 아이콘 표시
선택된 아이돌에만 표시되도록 조건부 렌더링 적용

Resolves: #85
Ref: #83

## 📝 Summary

투표 모달에서 선택한 아이돌 이미지 위에 체크 아이콘이 표시되도록 구현하고,  
`CheckIdol` 컴포넌트에 `isVote` prop을 추가하여 투표 화면에서만 다른 스타일을 적용할 수 있도록 개선했습니다.

## 🔧 Changes

- `CheckIdol` 컴포넌트에 `isVote` prop 추가
- `isVote`가 true일 경우 체크 아이콘 위치 변경 (`left: 21%`)
- 투표 모달에서 아이돌 선택 시 해당 이미지 위에 체크 아이콘 표시되도록 수정
- `VoteIdolList`에서 `CheckIdol` 호출 시 `isVote={true}` 전달

## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

- 투표 모달에서 아이돌 클릭 시 이미지 위에 체크 아이콘이 정상적으로 표시되는지 확인
- 다른 화면에서는 기존 스타일이 적용되고, 체크 아이콘이 보이지 않는지 확인

## 🖼️ Screenshots (UI 변경 시)

| 변경 전 | 변경 후 |
| ------- | ------- |
| ------- | ![image](https://github.com/user-attachments/assets/5b2607f0-27a9-4b7d-a4f2-08ff4abb0a21) |

## 📚 Additional

- `CheckIdol` 컴포넌트 스타일 중복을 줄이기 위해 CSS 구조도 일부 리팩토링했습니다.
- 아마도 이 PR은 다크호스일지도... 🎩✨

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
> 지금 커피 한잔 해야겠네용..ㅎ
