### PR TITLE
♻️ Chart 반응형 스타일 적용 (모바일/태블릿 대응)

### DIFF
--- a/src/pages/List/Chart/Chart.styles.js
+++ b/src/pages/List/Chart/Chart.styles.js
@@ -1,13 +1,11 @@
 import styled from "@emotion/styled";
 
-// 전체 컨테이너
 export const ChartContainer = styled.div`
-  max-width: 1200px;
   margin: 0 auto;
   padding: 40px 0;
+  width: clamp(327px, 90vw, 1200px);
 `;
 
-// 상단: 제목 + 버튼
 export const ChartHeaderWrap = styled.div`
   display: flex;
   justify-content: space-between;
@@ -24,7 +22,6 @@ export const ChartTitle = styled.h2`
 
 export const ChartButtonWrap = styled.div``;
 
-// 성별 탭
 export const ChartIdol = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -45,37 +42,40 @@ const ChartIdolBase = styled.div`
 `;
 
 export const ChartIdolLeft = styled(ChartIdolBase)`
-  background-color: #ffffff1a;
-  border-bottom: 1px solid #ffffff;
-`;
-
-export const ChartIdolRight = styled(ChartIdolBase)`
-  color: #828282;
-`;
-
-// 아이돌 리스트 영역
-export const ChartList = styled.div`
-  display: flex;
-  justify-content: space-between;
-  gap: 32px;
-  margin-top: 24px;
+  
   
 `;
 
-// 각 열
-export const ChartColumn = styled.ul`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+export const ChartIdolRight = styled(ChartIdolBase)`
+  
 `;
 
-// 리스트 아이템
+export const ChartList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 24px;
+
+  @media (min-width: 769px) {
+    flex-direction: row;
+    & > li {
+      width: calc(50% - 8px);
+    }
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    & > li {
+      width: 100%;
+    }
+  }
+`;
+
 export const ListItem = styled.li`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom:8px;
+  padding-bottom: 8px;
   border-bottom: 1px solid #ffffff1a;
 `;
 
@@ -95,7 +95,7 @@ export const RankAndName = styled.div`
     color: #f96d69;
     font-weight: 400;
     font-size: 16px;
-     opacity :0.57;
+    opacity: 0.57;
   }
 
   .group {
@@ -116,7 +116,6 @@ export const Votes = styled.span`
   font-family: Pretendard;
 `;
 
-// 더보기 버튼
 export const MoreButton = styled.div`
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## 📝 Summary

-모바일·태블릿 환경에서 Chart 리스트 1열로 변경 및 개수 5개 제한, vw 기반 width 적용 Resolves:#89

## 🔧 Changes

<!-- 주요 변경 내용을 요약해주세요 -->

- 이달의 남자 아이돌 탭 누를시 border-bottom 적용, 선택된 탭만 bg 설정, transition: "all 0.3s ease" 적용
- 태블릿, 모바일 범위내에서 이달의차트 아이돌 리스트가 2열이 아닌 1열로 설정


## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

## 🖼️ Screenshots (UI 변경 시)

https://github.com/user-attachments/assets/4671749c-febf-4b79-9279-0b635a7eeee2



## 📚 Additional

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->

- 아마도 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
