### PR TITLE
✨ Feat: Error 컴포넌트 구현

### DIFF
--- a/src/components/Error/Error.style.js
+++ b/src/components/Error/Error.style.js
@@ -1,0 +1,90 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+
+/**
+ * 에러 컴포넌트의 전체 레이아웃을 구성하는 wrapper 스타일
+ * 수직 정렬과 가운데 정렬을 통해 중앙에 요소를 배치
+ */
+export const errorWrapper = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+`;
+
+/**
+ * 느낌표 아이콘 border 원형 배경 스타일
+ * 선형 그라데이션 배경과 원형 테두리를 적용하여 시각적으로 강조
+ */
+export const iconWrapper = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 90px;
+  height: 90px;
+  margin-bottom: 16px; /* 'margin: button' 오타 수정 */
+  background: linear-gradient(90deg, #F86F65 0%, #FE5493 100%);
+  border-radius: 50%;
+  z-index: 0;
+`;
+
+/**
+ * 아이콘의 내부 원형(검은색 배경) 스타일
+ * iconWrapper 안에 정중앙에 위치하며, 내부 아이콘을 감싸는 역할
+ */
+export const black = css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #000000; /* = 대신 : */
+  width: 75px;
+  height: 75px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+`;
+
+/**
+ * 흰색 느낌표 아이콘 스타일입니다.
+ */
+export const icon = css`
+  font-size: 50px;
+  font-weight: 800;
+  color: #ffffff;
+  z-index: 2;
+`;
+
+/**
+ * 에러 제목 텍스트 스타일
+ */
+export const title = css`
+  font-size: 20px;
+  font-weight: 800;
+  color: #ffffff;
+`;
+
+/**
+ * 에러 상세 설명 텍스트 스타일
+ */
+export const description = css`
+  font-size: 15px;
+  color: #ffffff;
+`;
+
+/**
+ * '다시 시도하기' 버튼 스타일
+ */
+export const button = css`
+width: 140px;
+height: 30px;
+
+background: linear-gradient(90deg, #F86F65 0%, #FE5493 100%); 
+border-radius: 20px;
+
+font-size: 12px;
+font-weight: 400;`;

--- a/src/components/Error/index.jsx
+++ b/src/components/Error/index.jsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource @emotion/react */
+
+import {
+	black,
+	button,
+	description,
+	errorWrapper,
+	icon,
+	iconWrapper,
+	title,
+} from "./Error.style";
+
+const ERROR_MESSAGE = {
+	donation: "후원 목록을",
+	chart: "아이돌 목록을",
+	mypage: "아이돌을",
+};
+
+/**
+ * 에러 발생 시 사용자에게 메시지를 보여주는 컴포넌트입니다.
+ *
+ * @param {Object} props - 컴포넌트에 전달되는 props
+ * @param {"donation"|"chart"|"myPage"|string} [props.error="페이지를"] - 에러가 발생한 영역을 식별하는 키 값.
+ *        `ERROR_MESSAGE` 객체의 키값 중 하나를 전달하면 해당 메시지가 자동으로 전달됩니다.
+ *        정의되지 않은 값이 들어오면 그대로 출력됩니다.
+ * @returns 오류 메시지와 다시 시도 버튼
+ */
+function LodaingError({ error = "페이지를" }) {
+	const errorMessage = ERROR_MESSAGE[error] || error;
+
+	const handleReroad = () => {
+		location.reload();
+	};
+	return (
+		<div css={errorWrapper}>
+			<div css={iconWrapper}>
+				<div css={black}>
+					<div css={icon}>!</div>
+				</div>
+			</div>
+			<h1 css={title}>문제가 발생했습니다.</h1>
+			<p css={description}>{errorMessage} 불러오는데 실패했습니다.</p>
+			<button onClick={handleReroad} css={button} type="button">
+				다시 시도하기
+			</button>
+		</div>
+	);
+}
+
+export default LodaingError;

--- a/src/pages/List/Donation/Donation.style.js
+++ b/src/pages/List/Donation/Donation.style.js
@@ -41,7 +41,7 @@ export const pageNationRight = css`
   border-radius: 4px;
   }
 
-  @media (max-width: 769px) {
+  @media (max-width: 1365px) {
   display: none;
   }
 
@@ -69,7 +69,7 @@ export const pageNationLeft = css`
   border-radius: 4px;
   }
 
-  @media (max-width: 769px) {
+  @media (max-width: 1365px) {
   display: none;
   }
 `;

--- a/src/pages/List/Donation/index.jsx
+++ b/src/pages/List/Donation/index.jsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { donationTitle } from "./Donation.style";
 
 import { donationsAPI } from "../../../apis/donationsAPI";
+import LodaingError from "../../../components/Error";
 import Card from "./components/Card";
 import Carousel from "./components/Carousel";
 
@@ -56,9 +57,7 @@ function Donation() {
 				/>
 			)}
 
-			{!loading && donations.length === 0 && (
-				<div>현재 진행 중인 후원이 없습니다.</div>
-			)}
+			{!loading && donations.length === 0 && <LodaingError />}
 		</section>
 	);
 }


### PR DESCRIPTION
## 📝 Summary

에러 발생시 사용자에게 안내 메세지를 보여주는 Error 컴포넌트를 공통 컴포넌트로 구현하여 각 페이지 에러 처리 사용할 수 있도록 했습니다.
#87 

## 🔧 Changes

- prop으로 `error`를 전달받으며 해당 prop은 에러 메세지에 사용됩니다.

- 페이지별 에러 메세지를 구분해 선언해 두었으며, `donation`, `chart`, `mypage`로 값을 전달해 사용가능합니다. 이 외에 다른 문구를 넘겨주고 싶다면 해당 문구를 작성해주시면 됩니다.

- 다시 시도하기 버튼을 추가해 에러 발생시 해당 페이지 새로고침 기능을 추가했습니다.

- Donation 컴포넌트 캐러셀 화살표를 `1365px`부터 사라지도록 리펙토링 했습니다.

## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

- donationAPI에서 Error를 고의적으로 발생시켜 테스트를 진행했습니다.

- Donation 컴포넌트 내부 에러처리 부분에 <LoadingError /> 컴포넌트를 연결시켜 테스트 진행했습니다.

![스크린샷 2025-04-23 175315](https://github.com/user-attachments/assets/bf529d53-0491-46db-983b-5836c471aa59)


## 🖼️ Screenshots (UI 변경 시)

- `donation` `chart` `mypage` `원하는 말(원하는 문구를 전달)` 각 케이스의 예시입니다.

| donation | chart | mypage | 원하는 문구
| ------- | ------- | ------- | ------- |
| ![스크린샷 2025-04-23 175437](https://github.com/user-attachments/assets/785dbd22-101a-4dae-973f-bada8ab55e45)| ![스크린샷 2025-04-23 175448](https://github.com/user-attachments/assets/7dc70b01-4a10-4890-becd-400dd8ba7bd3)| ![스크린샷 2025-04-23 175504](https://github.com/user-attachments/assets/94aeccc1-165b-4a56-9f07-e4c978ebbc39) | ![스크린샷 2025-04-23 175516](https://github.com/user-attachments/assets/1c5c9ba3-8848-4d8f-9636-483dfa2f55e9)


## 📚 Additional

- 아마도 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
