### PR TITLE
Feature/vote modal mobile responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "vite --host",
 		"build": "vite build",
 		"lint": "biome lint --write",
 		"format": "biome format --write",

--- a/public/icons/icon-arrow-left.svg
+++ b/public/icons/icon-arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 19L9 12L16 5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/CheckIdol.jsx
+++ b/src/components/CheckIdol.jsx
@@ -3,11 +3,11 @@ import { css } from "@emotion/react";
 
 // size: 아이돌 원 사이즈
 // checkSize: 체크표시 사이즈
-const CheckIdol = ({ isChecked, size, checkSize, isVote = false }) => {
+const CheckIdol = ({ isChecked, size, checkSize }) => {
 	if (!isChecked) return null;
 
 	return (
-		<div css={checkWrapper(size, isVote)}>
+		<div css={checkWrapper(size)}>
 			<div css={checkBackground(size)} />
 			<img
 				src="../public/icons/Checkmark.png"
@@ -18,10 +18,10 @@ const CheckIdol = ({ isChecked, size, checkSize, isVote = false }) => {
 	);
 };
 
-const checkWrapper = (size, isVote) => css`
+const checkWrapper = (size) => css`
   position: absolute;
   top: 50%;
-  left: ${isVote ? "21%" : "50%"};
+  left: 50%;
   transform: translate(-50%, -50%);
   width: ${size}px;
   height: ${size}px;

--- a/src/components/Circle.jsx
+++ b/src/components/Circle.jsx
@@ -11,6 +11,7 @@ export const ImageCircle = styled.div`
   border: 1.31px solid #f96868;
   align-items: center;
    object-position:center;
+   position: relative;
 `;
 // 원하는 사이즈가 있으면 <Circle size=""/> 없을 시 기본 128px
 // 아이돌 이미지가 Circle frame보다 더 작게하기 위해 *0.9
@@ -26,7 +27,7 @@ const IdolImage = styled.img`
   
 `;
 
-const Circle = ({ imageUrl, alt, size, ...props }) => {
+const Circle = ({ imageUrl, alt, size, children, ...props }) => {
 	return (
 		<ImageCircle size={size}>
 			<IdolImage
@@ -36,6 +37,7 @@ const Circle = ({ imageUrl, alt, size, ...props }) => {
 				loading="eager"
 				{...props}
 			/>
+			{children}
 		</ImageCircle>
 	);
 };

--- a/src/components/Modal/Modal.styles.js
+++ b/src/components/Modal/Modal.styles.js
@@ -11,13 +11,11 @@ export const rootStyles = (isFullScreen) => css`
   ${
 		isFullScreen
 			? `
-    display: block;
-  `
-			: `
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  `
+      display: block;
+      `
+			: `display: flex; 
+      justify-content: center; 
+      align-items: center; `
 	}
 `;
 

--- a/src/components/Modal/Modal.styles.js
+++ b/src/components/Modal/Modal.styles.js
@@ -28,24 +28,28 @@ export const backdropStyles = css`
   background-color: rgba(0, 0, 0, 0.5);
 `;
 
-export const modalStyles = (isFullScreen) => css`
+export const modalStyles = (isFullScreen, type) => css`
   position: relative;
-  background-color:${isFullScreen ? "var(--black-02000E)" : " var(--black-181D26)"};
-  padding: 24px 16px 32px 16px;
+  background-color: ${isFullScreen ? "var(--black-02000E)" : "var(--black-181D26)"};
   gap: 8px;
-
+  padding: ${
+		type === "credit"
+			? "24px 16px 32px 16px" // credit 타입일 경우
+			: "24px 16px 12px 16px" // 그 외에는 기본 패딩
+	};
+  
   ${
 		isFullScreen
 			? `
     width: 100%;
     height: 100%;
     border-radius: 0;
-  `
+    `
 			: `
     min-width: 340px;
     min-height: 320px;
     border-radius: 12px;
-  `
+    `
 	}
 `;
 

--- a/src/components/Modal/Modal.styles.js
+++ b/src/components/Modal/Modal.styles.js
@@ -32,7 +32,10 @@ export const backdropStyles = css`
 
 export const modalStyles = (isFullScreen) => css`
   position: relative;
-  background-color: var(--black-181D26);
+  background-color:${isFullScreen ? "var(--black-02000E)" : " var(--black-181D26)"};
+  padding: 24px 16px 32px 16px;
+  gap: 8px;
+
   ${
 		isFullScreen
 			? `
@@ -46,10 +49,6 @@ export const modalStyles = (isFullScreen) => css`
     border-radius: 12px;
   `
 	}
-
-  padding: 24px 16px 32px 16px;
-  gap: 8px;
-  overflow-y: auto;
 `;
 
 export const modalHeaderStyles = (isFullScreen) => css`
@@ -62,10 +61,9 @@ export const modalHeaderStyles = (isFullScreen) => css`
   h2 {
     color: var(--white-F7F7F8);
     font-size: 18px;
-    font-style: normal;
     font-weight: 600;
     line-height: normal;
-    ${isFullScreen ? "position: absolute; left: 50%; transform: translateX(-50%);" : ""}
+    ${isFullScreen && "position: absolute; left: 50%; transform: translateX(-50%);"}
   }
 `;
 
@@ -74,20 +72,12 @@ export const buttonStyles = (isFullScreen) => css`
   border: none;
   padding: 0;
   cursor: pointer;
+  position: relative; 
 
   img {
     width: 24px;
     height: 24px;
   }
 
-  ${
-		isFullScreen
-			? `
-    position: relative;
-    margin-right: auto;
-  `
-			: `
-    position: relative;
-  `
-	}
+  ${isFullScreen && "margin-right: auto;"}
 `;

--- a/src/components/Modal/Modal.styles.js
+++ b/src/components/Modal/Modal.styles.js
@@ -1,18 +1,24 @@
-// src/components/Modal/Modal.styles.js
 import { css } from "@emotion/react";
 
-export const rootStyles = css`
+export const rootStyles = (isFullScreen) => css`
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 100%;
   z-index: 1000;
+
+  ${
+		isFullScreen
+			? `
+    display: block;
+  `
+			: `
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `
+	}
 `;
 
 export const backdropStyles = css`
@@ -24,37 +30,64 @@ export const backdropStyles = css`
   background-color: rgba(0, 0, 0, 0.5);
 `;
 
-export const modalStyles = css`
+export const modalStyles = (isFullScreen) => css`
   position: relative;
-  min-width: 340px;
-  min-height: 320px;
+  background-color: var(--black-181D26);
+  ${
+		isFullScreen
+			? `
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  `
+			: `
+    min-width: 340px;
+    min-height: 320px;
+    border-radius: 12px;
+  `
+	}
+
   padding: 24px 16px 32px 16px;
   gap: 8px;
-  background-color: var(--black-181D26);
-  border-radius: 12px;
+  overflow-y: auto;
 `;
 
-export const modalHeaderStyles = css`
-  display : flex;
-  justify-content: space-between;
+export const modalHeaderStyles = (isFullScreen) => css`
+  display: flex;
   align-items: center;
+  justify-content: ${isFullScreen ? "flex-start" : "space-between"};
   margin-bottom: 24px;
-  
+  position: relative;
+
   h2 {
     color: var(--white-F7F7F8);
     font-size: 18px;
     font-style: normal;
     font-weight: 600;
     line-height: normal;
+    ${isFullScreen ? "position: absolute; left: 50%; transform: translateX(-50%);" : ""}
   }
 `;
 
-export const buttonStyles = css`
+export const buttonStyles = (isFullScreen) => css`
   background: none;
   border: none;
+  padding: 0;
   cursor: pointer;
+
   img {
     width: 24px;
     height: 24px;
   }
+
+  ${
+		isFullScreen
+			? `
+    position: relative;
+    margin-right: auto;
+  `
+			: `
+    position: relative;
+  `
+	}
 `;

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
-import closeImg from "../../../public/images/btn-modal-close.png";
+import React, { useState, useEffect } from "react";
+import closeArrow from "/public/icons/icon-arrow-left.svg";
+import closeImg from "/public/images/btn-modal-close.png";
 import {
 	backdropStyles,
 	buttonStyles,
@@ -16,6 +17,21 @@ import ModalPortal from "./ModalPortal";
  * @param {Function} props.onClose
  * @param {React.ReactNode} props.children
  */
+
+const useIsMobile = () => {
+	const [isMobile, setIsMobile] = useState();
+
+	useEffect(() => {
+		const handleResize = () => {
+			setIsMobile(window.innerWidth <= 768);
+		};
+		handleResize();
+		window.addEventListener("resize", handleResize);
+		return () => window.removeEventListener("resize", handleResize);
+	}, []);
+
+	return isMobile;
+};
 
 const modalData = {
 	donation: {
@@ -38,10 +54,19 @@ const modalData = {
 	},
 };
 
-const Modal = ({ isOpen, onClose, type = "default", children }) => {
-	if (!isOpen) return null;
+const Modal = ({
+	isOpen,
+	onClose,
+	children,
+	type = "default",
+	isMobileFullScreen = false,
+}) => {
+	const isMobile = useIsMobile();
+	const isFullScreen = isMobile && isMobileFullScreen;
 
 	const { title } = modalData[type] || modalData.default; // type에 맞는 title 가져오기
+
+	if (!isOpen) return null;
 
 	const handleKeyDown = (event) => {
 		// Enter 키 또는 Space 키를 눌렀을 때 모달 닫기
@@ -52,7 +77,7 @@ const Modal = ({ isOpen, onClose, type = "default", children }) => {
 
 	return (
 		<ModalPortal>
-			<div css={rootStyles}>
+			<div css={rootStyles(isFullScreen)}>
 				{/* Backdrop */}
 				<button
 					css={backdropStyles}
@@ -64,17 +89,20 @@ const Modal = ({ isOpen, onClose, type = "default", children }) => {
 					{/* 비어 있는 버튼이지만 키보드 포커스와 역할이 명확함 */}
 				</button>
 				{/* Modal */}
-				<div css={modalStyles}>
-					<div css={modalHeaderStyles}>
+				<div css={modalStyles(isFullScreen)}>
+					<div css={modalHeaderStyles(isFullScreen)}>
 						<h2>{title}</h2>
 						<button
-							css={buttonStyles}
+							css={buttonStyles(isFullScreen)}
 							onClick={onClose}
 							onKeyDown={handleKeyDown} // 키보드 이벤트 처리
 							type="button"
 							aria-label="모달 창 닫기" // 접근성을 위한 aria-label
 						>
-							<img src={closeImg} alt="모달 창 닫기 버튼" />
+							<img
+								src={isFullScreen ? closeArrow : closeImg}
+								alt="모달 닫기 버튼"
+							/>
 						</button>
 					</div>
 					{/* Modal Content */}

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -20,9 +20,6 @@ import ModalPortal from "./ModalPortal";
  */
 
 const modalData = {
-	donation: {
-		title: "후원하기",
-	},
 	credit: {
 		title: "크레딧 충전",
 	},
@@ -31,9 +28,6 @@ const modalData = {
 	},
 	voteMan: {
 		title: "이달의 남자 아이돌",
-	},
-	insufficientCredits: {
-		title: "크레딧 부족", // 크레딧 부족 모달에 맞는 title
 	},
 	default: {
 		title: "기본 모달",
@@ -89,7 +83,7 @@ const Modal = ({
 					{/* 비어 있는 버튼이지만 키보드 포커스와 역할이 명확함 */}
 				</button>
 				{/* Modal */}
-				<div css={modalStyles(isFullScreen)}>
+				<div css={modalStyles(isFullScreen, type)}>
 					<div css={modalHeaderStyles(isFullScreen)}>
 						<h2>{title}</h2>
 						<button

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource @emotion/react */
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import closeArrow from "/public/icons/icon-arrow-left.svg";
 import closeImg from "/public/images/btn-modal-close.png";
+import useIsMobile from "../../hooks/useIsMobile";
 import {
 	backdropStyles,
 	buttonStyles,
@@ -17,21 +18,6 @@ import ModalPortal from "./ModalPortal";
  * @param {Function} props.onClose
  * @param {React.ReactNode} props.children
  */
-
-const useIsMobile = () => {
-	const [isMobile, setIsMobile] = useState();
-
-	useEffect(() => {
-		const handleResize = () => {
-			setIsMobile(window.innerWidth <= 768);
-		};
-		handleResize();
-		window.addEventListener("resize", handleResize);
-		return () => window.removeEventListener("resize", handleResize);
-	}, []);
-
-	return isMobile;
-};
 
 const modalData = {
 	donation: {
@@ -61,10 +47,24 @@ const Modal = ({
 	type = "default",
 	isMobileFullScreen = false,
 }) => {
-	const isMobile = useIsMobile();
+	const isMobile = useIsMobile(); // 여기에서 조건을 하지 않고 항상 호출됨
 	const isFullScreen = isMobile && isMobileFullScreen;
 
 	const { title } = modalData[type] || modalData.default; // type에 맞는 title 가져오기
+
+	// 모달이 열릴 때 body에 overflow-y: hidden 적용
+	useEffect(() => {
+		if (isOpen) {
+			document.body.style.overflowY = "hidden"; // 세로 스크롤만 막기
+		} else {
+			document.body.style.overflowY = ""; // 원래 상태로 복원
+		}
+
+		// 클린업: 모달이 닫히면 스크롤 복원
+		return () => {
+			document.body.style.overflowY = "";
+		};
+	}, [isOpen]);
 
 	if (!isOpen) return null;
 

--- a/src/components/RadioButton/index.jsx
+++ b/src/components/RadioButton/index.jsx
@@ -10,6 +10,7 @@ const voteRadioButton = css`
   justify-content: space-between;
   width: 477px;
   height: 70px;
+	
 `;
 
 // 크레딧 모달창 스타일 정의 & 선택된 경우 border 색상 변경 (input display:none으로 설정해서 className을 지정해 border색상 변경)
@@ -35,13 +36,13 @@ const inputStyle = css`
 `;
 
 // 라벨 내부 콘텐츠 영역 스타일
-const contenteWrapper = css`
+const contentWrapper = (className) => css`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   height: 100%;
-  padding: 0 16px;
+   padding: ${className === "vote" ? "0" : "0 23px 0 16px"};
 `;
 
 // 라디오 버튼 스타일 정의
@@ -81,7 +82,7 @@ function RadioButton({ value, checked, onChange, children, className }) {
 			/>
 
 			{/* 라벨 내부 콘텐츠: children + 선택 상태에 따라 아이콘 변경 */}
-			<div css={contenteWrapper}>
+			<div css={contentWrapper(className)}>
 				<div>{children}</div>
 				<img
 					src={checked ? radioTrue : radioFalse}

--- a/src/components/RadioButton/index.jsx
+++ b/src/components/RadioButton/index.jsx
@@ -10,7 +10,10 @@ const voteRadioButton = css`
   justify-content: space-between;
   width: 477px;
   height: 70px;
-	
+
+	@media (max-width: 425px) {
+    width: 100%;
+  }
 `;
 
 // 크레딧 모달창 스타일 정의 & 선택된 경우 border 색상 변경 (input display:none으로 설정해서 className을 지정해 border색상 변경)

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -1,0 +1,18 @@
+// hooks/useIsMobile.js
+import { useEffect, useState } from "react";
+
+export default function useIsMobile() {
+	const [isMobile, setIsMobile] = useState(false);
+
+	useEffect(() => {
+		const handleResize = () => {
+			setIsMobile(window.innerWidth <= 425);
+		};
+
+		handleResize(); // 초기 실행
+		window.addEventListener("resize", handleResize);
+		return () => window.removeEventListener("resize", handleResize);
+	}, []);
+
+	return isMobile;
+}

--- a/src/pages/List/Chart/IdolProfileModal.jsx
+++ b/src/pages/List/Chart/IdolProfileModal.jsx
@@ -1,4 +1,0 @@
-const IdolProfileModal = () => {
-	return <div></div>;
-};
-export default IdolProfileModal;

--- a/src/pages/List/Chart/components/ChartVoteModal.jsx
+++ b/src/pages/List/Chart/components/ChartVoteModal.jsx
@@ -67,10 +67,14 @@ export default function ChartVoteModal({ idols, setIdols, closeModal }) {
 }
 
 const VoteFormStyles = css`
-  height: 100vh;         // 이게 있어야 max-height도 의미 있음
+   
   max-height: 100vh;
   overflow-y: hidden;
   position: relative;    // 또는 fixed/absolute 등 상황에 맞게
+
+	@media (max-width: 425px) {
+		height: 100vh;
+	}
 `;
 
 const yourButtonStyle = css`
@@ -83,4 +87,5 @@ const yourButtonStyle = css`
   //   background-color: rgba(2, 0, 14, 0.8);  // 반투명 배경
   //   z-index: 1;
   // }
+
 `;

--- a/src/pages/List/Chart/components/ChartVoteModal.jsx
+++ b/src/pages/List/Chart/components/ChartVoteModal.jsx
@@ -69,8 +69,7 @@ export default function ChartVoteModal({ idols, setIdols, closeModal }) {
 const VoteFormStyles = css` 
   max-height: 100vh;
   overflow-y: hidden;
-  position: relative;    // 또는 fixed/absolute 등 상황에 맞게
-
+  position: relative; 
 	@media (max-width: 425px) {
 		height: 100vh;
 	}

--- a/src/pages/List/Chart/components/ChartVoteModal.jsx
+++ b/src/pages/List/Chart/components/ChartVoteModal.jsx
@@ -1,4 +1,6 @@
 /** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+
 import { useState } from "react";
 import { votesAPI } from "../../../../apis/voteApi";
 import { useCredit } from "../../../../context/CreditContext";
@@ -53,13 +55,32 @@ export default function ChartVoteModal({ idols, setIdols, closeModal }) {
 	};
 
 	return (
-		<form onSubmit={handleVote}>
+		<form onSubmit={handleVote} css={VoteFormStyles}>
 			<VoteIdolList
 				idols={idols}
 				selectedIdolId={selectedIdolId}
 				onSelectIdol={handleIdolSelect}
 			/>
-			<VoteButton onSubmit={handleVote} />
+			<VoteButton onSubmit={handleVote} css={yourButtonStyle} />
 		</form>
 	);
 }
+
+const VoteFormStyles = css`
+  height: 100vh;         // 이게 있어야 max-height도 의미 있음
+  max-height: 100vh;
+  overflow-y: hidden;
+  position: relative;    // 또는 fixed/absolute 등 상황에 맞게
+`;
+
+const yourButtonStyle = css`
+  // @media (max-width: 425px) {
+  //   position: fixed;
+  //   bottom: 0;
+  //   left: 0;
+  //   width: 100%;
+  //   padding: 16px 0;
+  //   background-color: rgba(2, 0, 14, 0.8);  // 반투명 배경
+  //   z-index: 1;
+  // }
+`;

--- a/src/pages/List/Chart/components/ChartVoteModal.jsx
+++ b/src/pages/List/Chart/components/ChartVoteModal.jsx
@@ -61,13 +61,12 @@ export default function ChartVoteModal({ idols, setIdols, closeModal }) {
 				selectedIdolId={selectedIdolId}
 				onSelectIdol={handleIdolSelect}
 			/>
-			<VoteButton onSubmit={handleVote} css={yourButtonStyle} />
+			<VoteButton onSubmit={handleVote} />
 		</form>
 	);
 }
 
-const VoteFormStyles = css`
-   
+const VoteFormStyles = css` 
   max-height: 100vh;
   overflow-y: hidden;
   position: relative;    // 또는 fixed/absolute 등 상황에 맞게
@@ -75,17 +74,4 @@ const VoteFormStyles = css`
 	@media (max-width: 425px) {
 		height: 100vh;
 	}
-`;
-
-const yourButtonStyle = css`
-  // @media (max-width: 425px) {
-  //   position: fixed;
-  //   bottom: 0;
-  //   left: 0;
-  //   width: 100%;
-  //   padding: 16px 0;
-  //   background-color: rgba(2, 0, 14, 0.8);  // 반투명 배경
-  //   z-index: 1;
-  // }
-
 `;

--- a/src/pages/List/Chart/components/VoteButton.jsx
+++ b/src/pages/List/Chart/components/VoteButton.jsx
@@ -9,7 +9,12 @@ export default function VoteButton({ onSubmit }) {
 
 	return (
 		<div css={centerAlignStyle}>
-			<Button type="submit" size={buttonSize} onClick={onSubmit}>
+			<Button
+				type="submit"
+				size={buttonSize}
+				fullWidth={true}
+				onClick={onSubmit}
+			>
 				투표하기
 			</Button>
 			<p css={CreditInfo}>

--- a/src/pages/List/Chart/components/VoteButton.jsx
+++ b/src/pages/List/Chart/components/VoteButton.jsx
@@ -1,11 +1,15 @@
 /** @jsxImportSource @emotion/react */
 import Button from "../../../../components/Button/Button";
+import useIsMobile from "../../../../hooks/useIsMobile";
 import { CreditInfo, centerAlignStyle } from "./VoteButton.styles";
 
 export default function VoteButton({ onSubmit }) {
+	const isMobile = useIsMobile();
+	const buttonSize = isMobile ? "vote-md" : "vote-lg";
+
 	return (
 		<div css={centerAlignStyle}>
-			<Button type="submit" size="vote-lg" onClick={onSubmit}>
+			<Button type="submit" size={buttonSize} onClick={onSubmit}>
 				투표하기
 			</Button>
 			<p css={CreditInfo}>

--- a/src/pages/List/Chart/components/VoteButton.styles.js
+++ b/src/pages/List/Chart/components/VoteButton.styles.js
@@ -14,7 +14,7 @@ export const centerAlignStyle = css`
     bottom: 0;
     left: 0;
     width: 100%;
-    padding: 16px 24px 14px 24px;
+    padding: 3.76vw 5.65vw 3.29vw 5.65vw;
     background: rgba(2, 0, 14, 0.8);
     z-index: 10;
   }

--- a/src/pages/List/Chart/components/VoteButton.styles.js
+++ b/src/pages/List/Chart/components/VoteButton.styles.js
@@ -1,5 +1,23 @@
 import { css } from "@emotion/react";
 
+export const centerAlignStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center; /* 텍스트 중앙 정렬 */
+
+   @media (max-width: 425px) {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding: 16px;
+    background-color: rgba(2, 0, 14, 0.8);
+    z-index: 10;
+  }
+`;
+
 export const CreditInfo = css`
   color: #FFFFFF;
   font-size: 12px;
@@ -10,12 +28,5 @@ export const CreditInfo = css`
   span {
     color: var(--orange-F96D69);
   }
-`;
-
-export const centerAlignStyle = () => css`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center; /* 텍스트 중앙 정렬 */
+    
 `;

--- a/src/pages/List/Chart/components/VoteButton.styles.js
+++ b/src/pages/List/Chart/components/VoteButton.styles.js
@@ -1,19 +1,21 @@
 import { css } from "@emotion/react";
 
 export const centerAlignStyle = css`
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center; /* 텍스트 중앙 정렬 */
 
+  
    @media (max-width: 425px) {
     position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
-    padding: 16px;
-    background-color: rgba(2, 0, 14, 0.8);
+    padding: 16px 24px 14px 24px;
+    background: rgba(2, 0, 14, 0.8);
     z-index: 10;
   }
 `;
@@ -23,7 +25,7 @@ export const CreditInfo = css`
   font-size: 12px;
   font-weight: 500;
   line-height: 26px;
-  margin-top: 10px;
+  margin-top: 8px;
 
   span {
     color: var(--orange-F96D69);

--- a/src/pages/List/Chart/components/VoteIdolList.jsx
+++ b/src/pages/List/Chart/components/VoteIdolList.jsx
@@ -37,13 +37,13 @@ export default function VoteIdolList({ idols, selectedIdolId, onSelectIdol }) {
 									alt={idol.name}
 									loading="lazy"
 									decoding="async"
-								/>
-								<CheckIdol
-									isVote={true}
-									isChecked={selectedIdolId === idol.id}
-									size={70}
-									checkSize={18}
-								/>
+								>
+									<CheckIdol
+										isChecked={selectedIdolId === idol.id}
+										size={70}
+										checkSize={18}
+									/>
+								</Circle>
 								<div css={IdolInfo}>
 									<span css={Rank}>{index + 1}</span>
 									<div css={IdolDetails}>

--- a/src/pages/List/Chart/components/VoteIdolList.styles.js
+++ b/src/pages/List/Chart/components/VoteIdolList.styles.js
@@ -8,11 +8,11 @@ export const IdolList = css`
 
   /* 웹킷 기반 브라우저용 스크롤바 스타일 */
   &::-webkit-scrollbar {
-    width: 4px;
+    width: 3px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: var(--orange-F96D69);
+    background-color: rgba(249, 109, 105, 0.5); /* 반투명한 오렌지 색 (50% 투명도) */
     border-radius: 3px;
   }
 
@@ -20,12 +20,13 @@ export const IdolList = css`
     background-color: transparent;
   }
 
- /* ✅ 모바일에서는 height를 화면 전체로 */
+
   @media (max-width: 425px) {
-    height: calc(100vh - 150px); /* 상단 여백과 버튼영역 고려해서 계산 */
-    max-height: none; /* max-height 제거 */
-  
+    max-height: calc(100vh - 76px); /* 버튼 영역 + 여유 */
+    overflow-y: auto;                /* ✅ 반드시 필요 */
+    padding-bottom: 96px;            /* 리스트 아이템 마지막 여백 */
   }
+
 `;
 
 export const IdolItem = css`

--- a/src/pages/List/Chart/components/VoteIdolList.styles.js
+++ b/src/pages/List/Chart/components/VoteIdolList.styles.js
@@ -19,6 +19,13 @@ export const IdolList = css`
   &::-webkit-scrollbar-track {
     background-color: transparent;
   }
+
+ /* ✅ 모바일에서는 height를 화면 전체로 */
+  @media (max-width: 425px) {
+    height: calc(100vh - 150px); /* 상단 여백과 버튼영역 고려해서 계산 */
+    max-height: none; /* max-height 제거 */
+  
+  }
 `;
 
 export const IdolItem = css`

--- a/src/pages/List/Chart/components/VoteIdolList.styles.js
+++ b/src/pages/List/Chart/components/VoteIdolList.styles.js
@@ -22,9 +22,9 @@ export const IdolList = css`
 
 
   @media (max-width: 425px) {
-    max-height: calc(100vh - 76px); /* 버튼 영역 + 여유 */
+    max-height: calc(100vh - 17.88vw); /* 버튼 영역 + 여유 */
     overflow-y: auto;                /* ✅ 반드시 필요 */
-    padding-bottom: 96px;            /* 리스트 아이템 마지막 여백 */
+    padding-bottom: 24vw;            /* 리스트 아이템 마지막 여백 */
   }
 
 `;

--- a/src/pages/List/Chart/index.jsx
+++ b/src/pages/List/Chart/index.jsx
@@ -115,6 +115,7 @@ const Chart = () => {
 				isOpen={isModalOpen}
 				onClose={closeModal}
 				type={activeTab === "female" ? "voteWoman" : "voteMan"} // activeTab에 따라 type 설정
+				isMobileFullScreen={true}
 			>
 				<ChartVoteModal
 					gender={activeTab}


### PR DESCRIPTION
## 📝 Summary

모바일(425px 이하) 환경에서 투표 모달(VoteModal)이 전체 화면으로 전환되도록 반응형 스타일을 적용하였습니다.  
고정된 투표 버튼과 크레딧 안내 문구가 모달 콘텐츠 위에 잘 표시되도록 z-index 및 배경 처리도 함께 조정하였습니다.

## 🔧 Changes

### 1. 공통 Modal 스타일 수정
- `@media (max-width: 425px)` 조건 추가
- 모바일 화면에서는 `position: fixed`, `top: 0`, `left: 0`, `width: 100%`, `height: 100%` 설정을 적용하여 전체 화면화

### 2. VoteButton 스타일 보완
- 고정된 투표 버튼(`VoteButton`)의 위치가 콘텐츠를 가리지 않도록 `z-index`, `padding-bottom` 조정
- 배경을 `rgba(2, 0, 14, 0.8)`로 설정해 아래 리스트가 살짝 비치도록 처리
- 안내 문구 `<p>` 태그도 같은 영역에 고정되도록 위치 지정

### 3. CheckIdol과 VoteIdolList 레이아웃 보완
- `CheckIdol` 컴포넌트를 `Circle` 내부에 children으로 삽입하여 아이돌 프로필 이미지 위에 아이콘이 겹쳐지도록 구조 변경
- Circle의 `position: relative`와 CheckIdol의 `position: absolute`를 조합해 정확한 위치에 표시

## ✅ Checklist

- [x] 모바일에서 모달이 전체 화면으로 보이는지 확인
- [x] 배경 투명도 및 고정 버튼/문구 시각적으로 문제 없는지 확인
- [x] 데스크톱 환경에서는 기존 레이아웃이 유지되는지 확인
- [x] 코드 리팩토링 및 스타일 중복 여부 검토

## 🚀 Test Plan

- [x] iPhone XR, Galaxy S 시뮬레이터에서 UI 테스트
- [x] 아이돌 선택 및 투표 기능 정상 동작 확인
- [x] 고정 버튼 클릭 시 크레딧 부족/성공 모달 정상 작동 여부 확인

## 📸 Screenshots (변경 UI)

| 변경 전 | 변경 후 |
|--------|--------|
||![image](https://github.com/user-attachments/assets/ada19b56-d95a-4649-ae5b-4c80f36fdcd5)| 
|![image](https://github.com/user-attachments/assets/ef5ad763-a206-443f-a2cc-9174dbbef162) |![image](https://github.com/user-attachments/assets/04edd068-742e-4eea-b57d-4067572d5648)|

## 🗂 Related

- Component: `Modal`, `VoteModal`, `VoteIdolList`, `CheckIdol`, `Circle`
- Style: Emotion (CSS-in-JS), media query 적용

## 📚 Additional
- 추후 다른 모달에서도 모바일 대응이 필요할 경우, `Modal`의 반응형 스타일을 기반으로 쉽게 확장 가능합니다.
- 디자인 의도상 전체 화면 모달 + 투명 배경 + 고정 버튼의 조합이 자연스럽게 어우러지도록 UX에 신경 썼습니다.

- 도와주신 수민님 정말 감사합니다 😍
- 아마도 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕

