### PR TITLE
🚑️ Fix: API 호출 에러 발생시 자동 재시도 로직 구현

### DIFF
--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -5,4 +5,50 @@ export const baseAPI = axios.create({
 	headers: {
 		"Content-Type": "application/json",
 	},
+	timeout: 10000, // 요청 하나당 최대 10초
 });
+
+const MAX_RETRY_TIME = 30000; // 총 30초 동안 재시도
+const RETRY_DELAY = 1000; // 재시도 간격 1초
+
+// 요청 인터셉터
+baseAPI.interceptors.request.use(
+	(config) => {
+		// 요청이 보내지기 전에 작업 수행
+		return config;
+	},
+	(error) => {
+		// 요청 에러 발생 시 처리
+		return Promise.reject(error);
+	},
+);
+
+// 응답 인터셉터
+baseAPI.interceptors.response.use(
+	(response) => {
+		// 응답이 정상일 때
+		return response;
+	},
+	async (error) => {
+		const config = error.config;
+
+		// 설정 정보가 없거나 이미 재시도 중이면 그대로 에러 반환
+		if (!config || config.__isRetryRequest) {
+			return Promise.reject(error);
+		}
+
+		// 최초 시도 시 설정
+		config.__isRetryRequest = true;
+		config.__retryCount = config.__retryCount || 0;
+		config.__startTime = config.__startTime || Date.now();
+
+		// 경과 시간이 30초 미만이면 재시도
+		if (Date.now() - config.__startTime < MAX_RETRY_TIME) {
+			await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY));
+			return baseAPI(config); // 재요청
+		}
+
+		// 30초 경과 시 에러 반환
+		return Promise.reject(error);
+	},
+);

--- a/src/apis/donationsAPI.js
+++ b/src/apis/donationsAPI.js
@@ -4,7 +4,9 @@ export const donationsAPI = {
 	// 조공 목록 조회
 	getDonations: async (pageSize = 10) => {
 		try {
-			const response = await baseAPI.get(`/15-3/donations?${pageSize}`);
+			const response = await baseAPI.get(
+				`/15-3/donations?pageSize=${pageSize}`,
+			);
 			return response.data;
 		} catch (error) {
 			throw new Error("목록을 불러오는데 실패했습니다.");

--- a/src/apis/donationsAPI.js
+++ b/src/apis/donationsAPI.js
@@ -2,7 +2,7 @@ import { baseAPI } from "./axios";
 
 export const donationsAPI = {
 	// 조공 목록 조회
-	getDonations: async (pageSize = 10) => {
+	getDonations: async (pageSize = 20) => {
 		try {
 			const response = await baseAPI.get(
 				`/15-3/donations?pageSize=${pageSize}`,


### PR DESCRIPTION
## 📝 Summary

서버 오류 발생 시 즉시 에러를 반환하지 않고, 30초 동안 1초 간격으로 재시도를 진행한 뒤에도 실패할 경우 에러를 반환하도록 하여, 과도한 에러 발생을 방지하고자 했습니다.
Resolves: #105

## 🔧 Changes

1. Axios 인스턴스에 요청 및 응답 인터셉터(interceptor) 추가

    - interceptor는 Axios에서 요청이나 응답을 가로채어 중간에서 로직을 삽입할 수 있도록 해주는 기능입니다.

    - 이를 통해 모든 API 요청/응답에 공통적인 처리 로직을 주입할 수 있습니다.

2. 응답 인터셉터에서 실패 요청에 대한 자동 재시도 로직 구현

   - 네트워크 오류, 서버 오류 발생 시, 요청을 즉시 실패 처리하지 않고 일정 시간 동안 재시도합니다.

    - 재시도 설정값 정의

         - MAX_RETRY_TIME: 최대 30초 동안 재시도

         - RETRY_DELAY: 각 재시도 간격은 1초

3. 재시도 조건 설정

   - 요청 객체(config)가 존재하고, 이전에 재시도한 요청이 아닌 경우, 최대 재시도 시간(MAX_RETRY_TIME) 이내인 경우에만 재시도 수행

      - config.__isRetryRequest: 재시도 중임을 표시하기 위한 값

      - config.__retryCount, config.__startTime: 재시도 횟수 및 시작 시간 기록

4. 성공 시 응답 정상 반환, 실패 시 최종적으로 에러 반환

    - 재요청 중 응답이 성공하면 그대로 반환

     - 30초가 경과할 경우 Promise.reject(error)로 에러 처리

5. 에러가 잦은 상황에서도 사용자에게 반복적인 에러 표시를 방지

   - 즉시 에러를 던지지 않음으로써 과도한 에러 컴포넌트 렌더링 방지

   - 서버가 일시적으로 불안정한 경우에도 자동으로 회복 가능



## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

- console에서 오류 발생시 자동으로 재시도가 되고, 응답이 다시 정상적으로 돌아오는지 확인했습니다.

![스크린샷 2025-04-24 175959](https://github.com/user-attachments/assets/5fb3882d-a217-48ef-b451-d8e328c18871)


## 🖼️ Screenshots (UI 변경 시)


## 📚 Additional

- API... 어렵습니다 ..... 

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
