### PR TITLE
Refactor/credit recharge improvement

### DIFF
--- a/src/pages/List/Charge/components/CreditCharge.jsx
+++ b/src/pages/List/Charge/components/CreditCharge.jsx
@@ -1,8 +1,8 @@
+import Modal from "@/components/Modal";
+import { useCredit } from "@/context/CreditContext";
 import { css } from "@emotion/react";
 import gsap from "gsap";
 import { useCallback, useEffect, useRef, useState } from "react";
-import Modal from "../../../../../src/components/Modal";
-import { useCredit } from "../../../../context/CreditContext";
 import CreditRechargeModalContent from "./CreditRechargeModalContent";
 /** @jsxImportSource @emotion/react */
 

--- a/src/pages/List/Charge/components/CreditRechargeModalContent.jsx
+++ b/src/pages/List/Charge/components/CreditRechargeModalContent.jsx
@@ -1,11 +1,11 @@
+import Button from "@/components/Button/Button";
+import RadioButton from "@/components/RadioButton";
+import { useCredit } from "@/context/CreditContext";
 // src/components/Modal/Modal.styles.js
 /** @jsxImportSource @emotion/react */
 import { useState } from "react";
 import { toast } from "react-toastify";
 import creditIcon from "/icons/icon_credit.svg";
-import Button from "../../../../../src/components/Button/Button";
-import RadioButton from "../../../../../src/components/RadioButton";
-import { useCredit } from "../../../../context/CreditContext";
 import {
 	RadioStyles,
 	buttonSpacing,

--- a/src/pages/List/Charge/components/CreditRechargeModalContent.jsx
+++ b/src/pages/List/Charge/components/CreditRechargeModalContent.jsx
@@ -1,6 +1,7 @@
 // src/components/Modal/Modal.styles.js
 /** @jsxImportSource @emotion/react */
 import { useState } from "react";
+import { toast } from "react-toastify";
 import creditIcon from "/icons/icon_credit.svg";
 import Button from "../../../../../src/components/Button/Button";
 import RadioButton from "../../../../../src/components/RadioButton";
@@ -56,7 +57,9 @@ export default function CreditRechargeModalContent({ myCredit, closeModal }) {
 					variant="primary"
 					disabled={select === null}
 					fullWidth
-					onClick
+					onClick={() =>
+						toast.success(`🎉 ${select.toLocaleString()} 크레딧 충전 완료!`)
+					}
 				>
 					충전하기
 				</Button>

--- a/src/pages/List/Charge/styles/CreditRechargeModalContent.styles.js
+++ b/src/pages/List/Charge/styles/CreditRechargeModalContent.styles.js
@@ -4,6 +4,7 @@ import { css } from "@emotion/react";
 // 각각의 라디오 버튼 컨테이너
 export const RadioStyles = css`
   margin-bottom: 8px;
+  background: var(--black-black_02000E, #02000E);
 `;
 
 // 라디오 버튼 + 텍스트 정렬


### PR DESCRIPTION
#134 
## 📝 Summary

<!-- 간단한 변경 요약을 작성해주세요 -->
- 크레딧 충전 모달에서 라디오 버튼 배경색을 Figma 디자인 가이드에 맞게 수정하였습니다.
- 크레딧 충전 시, 선택한 금액에 따라 성공 토스트 메시지를 띄우도록 구현하였습니다.

## 🔧 Changes

<!-- 주요 변경 내용을 요약해주세요 -->
- RadioButton 배경색 스타일 변경 (Figma 기준 적용)
- 크레딧 충전 성공 시 toast 메시지 추가 (`{선택 금액} 크레딧 충전됐습니다!`)
- 선택된 라디오 버튼 스타일 시각적으로 더 분명하게 표현

## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

<!-- 테스트 방법과 결과를 작성해주세요 -->
- 크레딧 충전 모달을 열고, 라디오 버튼 선택 시 배경색이 정상적으로 반영되는지 확인
- 크레딧 선택 후 충전 버튼을 클릭하여 toast 메시지가 정상 출력되는지 확인


## 🖼️ Screenshots (UI 변경 시)

변경 전  ![충전 모달 시현](https://github.com/user-attachments/assets/d8747883-d94f-47ec-ac56-fb4459512771)
변경 후 ![변경 후](https://github.com/user-attachments/assets/1e715a34-3c3b-4b97-9b49-d3d277e49397)

## 📚 Additional

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->
- toast 문구는 사용자 입장에서 직관적으로 이해할 수 있도록 구성했습니다
- toast 성공 문구에 이모티콘 넣어봤는데 어떤가요?
- 아마도 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
