### PR TITLE
♻️ Fix: 랜딩 페이지 하단에서 리스트로 이동했을 때 페이지 하단으로 이동하는 이슈 해결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useEffect, useRef } from "react";
 import { Route, Routes } from "react-router-dom";
+import ScrollToTop from "./components/ScrollTop";
 import Toastify from "./components/Toastify";
 import { CreditProvider } from "./context/CreditContext";
 import DefaultLayout from "./layouts/DefaultLayout";
@@ -40,6 +41,7 @@ function App() {
 	return (
 		<CreditProvider>
 			<Toastify />
+			<ScrollToTop />
 			<Routes>
 				<Route index element={<Landing />} />
 				<Route path="/" element={<DefaultLayout />}>

--- a/src/components/ScrollTop.jsx
+++ b/src/components/ScrollTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+	const { pathname } = useLocation();
+
+	useEffect(() => {
+		if (pathname) {
+			window.scrollTo(0, 0);
+		}
+	}, [pathname]);
+
+	return null;
+}


### PR DESCRIPTION
랜딩 페이지 하단에서 리스트로 이동했을 때 페이지 하단으로 이동하는 이슈 해결 Resolves: #184

## 📝 Summary

<!-- 간단한 변경 요약을 작성해주세요 -->
랜딩 페이지 하단에서 리스트로 이동했을 때 페이지 하단으로 이동하는 이슈 해결

## 🔧 Changes

<!-- 주요 변경 내용을 요약해주세요 -->

- ScrollTop.jsx 훅을 만들어서 App.jsx Route내부에 페이지가 이동할 때 (path가 변경될 때)마다 페이지 상단으로 이동하게 작업하였습니다.


## ✅ Checklist

- [x] 컨벤션을 준수하였습니다.
- [x] 변경 사항을 테스트하였습니다.
- [x] 설명을 충분히 작성하였습니다.
- [x] 올바른 브랜치에 PR을 보냈습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

<!-- 테스트 방법과 결과를 작성해주세요 -->

- 랜딩페이지 하단에 있는 버튼 링크로 이동해보세요.

## 📚 Additional

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->

- 아마도 이 PR은 다크호스일지도... 🎩✨
- 동환님 영상 작업하신거 보고 엇! 싶어서 찾아봤더니
- 싱글 페이지 애플리케이션(SPA)에서 흔히 발생하는 문제라고 하네요

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕
